### PR TITLE
Added .call() to the balanceOf token calls in the example code

### DIFF
--- a/frontend-integration/swap.md
+++ b/frontend-integration/swap.md
@@ -20,11 +20,11 @@ For sell orders \(exact input\), the amount bought \(output\) is calculated:
 // Sell ETH for ERC20
 const inputAmount = userInputEthValue
 const inputReserve = web3.eth.getBalance(exchangeAddress)
-const outputReserve = tokenContract.methods.balanceOf(exchangeAddress)
+const outputReserve = tokenContract.methods.balanceOf(exchangeAddress).call()
 
 // Sell ERC20 for ETH
 const inputAmount = userInputTokenValue
-const inputReserve = tokenContract.methods.balanceOf(exchangeAddress)
+const inputReserve = tokenContract.methods.balanceOf(exchangeAddress).call()
 const outputReserve = web3.eth.getBalance(exchangeAddress)
 
 // Output amount bought
@@ -41,11 +41,11 @@ For buy orders \(exact output\), the cost \(input\) is calculated:
 // Buy ERC20 with ETH
 const outputAmount = userInputTokenValue
 const inputReserve = web3.eth.getBalance(exchangeAddress)
-const outputReserve = tokenContract.methods.balanceOf(exchangeAddress)
+const outputReserve = tokenContract.methods.balanceOf(exchangeAddress).call()
 
 // Buy ETH with ERC20
 const outputAmount = userInputEthValue
-const inputReserve = tokenContract.methods.balanceOf(exchangeAddress)
+const inputReserve = tokenContract.methods.balanceOf(exchangeAddress).call()
 const outputReserve = web3.eth.getBalance(exchangeAddress)
 
 // Cost
@@ -87,7 +87,7 @@ For sell orders \(exact input\), the amount bought \(output\) is calculated:
 ```javascript
 // TokenA (ERC20) to ETH conversion
 const inputAmountA = userInputTokenAValue
-const inputReserveA = tokenContractA.methods.balanceOf(exchangeAddressA)
+const inputReserveA = tokenContractA.methods.balanceOf(exchangeAddressA).call()
 const outputReserveA = web3.eth.getBalance(exchangeAddressA)
 
 const numeratorA = inputAmountA * outputReserveA * 997
@@ -97,7 +97,7 @@ const outputAmountA = numeratorA / denominatorA
 // ETH to TokenB conversion
 const inputAmountB = outputAmountA
 const inputReserveB = web3.eth.getBalance(exchangeAddressB)
-const outputReserveB = tokenContract.methods.balanceOf(exchangeAddressB)
+const outputReserveB = tokenContract.methods.balanceOf(exchangeAddressB).call()
 
 const numeratorB = inputAmountB * outputReserveB * 997
 const denominatorB = inputReserveB * 1000 + inputAmountB * 997
@@ -112,7 +112,7 @@ For buy orders \(exact output\), the cost \(input\) is calculated:
 // Buy TokenB with ETH
 const outputAmountB = userInputEthValue
 const inputReserveB = web3.eth.getBalance(exchangeAddressB)
-const outputReserveB = tokenContractB.methods.balanceOf(exchangeAddressB)
+const outputReserveB = tokenContractB.methods.balanceOf(exchangeAddressB).call()
 
 // Cost
 const numeratorB = outputAmountB * inputReserveB * 1000
@@ -121,7 +121,7 @@ const inputAmountB = numeratorB / denominatorB + 1
 
 // Buy ETH with TokenA
 const outputAmountA = userInputEthValue
-const inputReserveA = tokenContractA.methods.balanceOf(exchangeAddressA)
+const inputReserveA = tokenContractA.methods.balanceOf(exchangeAddressA).call()
 const outputReserveA = web3.eth.getBalance(exchangeAddressA)
 
 // Cost


### PR DESCRIPTION
The example code in the Trade tokens section doesn't include a .call() attached to the balanceOf(address) invocation. As a result, if someone plugged in that code they wouldn't be returned any data. 