### PR TITLE
Factory API - Fix Web3 getTokenWithId docs

### DIFF
--- a/smart-contract-api/factory.md
+++ b/smart-contract-api/factory.md
@@ -106,7 +106,7 @@ getTokenWithId(token_id: uint256): address
 
 {% tab title="Web3" %}
 ```javascript
-factoryContract.methods.getToken(exchange).call()
+factoryContract.methods.getTokenWithId(token_id).call()
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
Just a small edition on the Factory contract documentation. The Web3 tab for getTokenWithId showed the getToken docs.